### PR TITLE
PTB-2248: Preserve session state across MCP tool calls

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "Vibe Prospecting",
   "display_name": "Vibe Prospecting",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Power your chat with B2B data to create lead lists, research companies, personalize your outreach, and more.",
   "long_description": "Search any company or professional to access emails, phone numbers, roles, growth signals, tech stack details, business events, website changes, and more. Use it to **find qualified leads**, **research prospects**, **create personalized outreach**, or **identify talent**, all directly within your chat. Vibe Prospecting provides fresh and compliant B2B data through a complete enrichment hub.",
   "author": {
@@ -24,10 +24,7 @@
     "entry_point": "server/index.js",
     "mcp_config": {
       "command": "node",
-      "args": [
-        "${__dirname}/node_modules/mcp-remote/dist/proxy.js",
-        "https://mcp-ext.vibeprospecting.ai/mcp"
-      ]
+      "args": ["${__dirname}/server/index.js"]
     }
   },
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explorium-mcp-extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explorium-mcp-extension",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "explorium-mcp-extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Explorium MCP Extension for Claude Desktop using mcp-remote",
+  "type": "module",
   "main": "server/index.js",
   "scripts": {
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,1 +1,65 @@
-console.log("Starting Explorium AgentSource MCP server...");
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { fileURLToPath } from "node:url";
+
+import { SessionStateBridge } from "./session-state.js";
+
+const REMOTE_MCP_URL = "https://mcp-ext.vibeprospecting.ai/mcp";
+const MCP_REMOTE_PATH = fileURLToPath(
+  new URL("../node_modules/mcp-remote/dist/proxy.js", import.meta.url),
+);
+
+const inheritedEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([, value]) => value !== undefined),
+);
+const localTransport = new StdioServerTransport();
+const remoteTransport = new StdioClientTransport({
+  command: process.execPath,
+  args: [MCP_REMOTE_PATH, REMOTE_MCP_URL],
+  env: inheritedEnvironment,
+  stderr: "inherit",
+});
+const sessionState = new SessionStateBridge();
+let closing = false;
+
+function reportError(source, error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[vibe-prospecting] ${source}: ${message}`);
+}
+
+async function closeTransports() {
+  if (closing) return;
+  closing = true;
+  await Promise.allSettled([localTransport.close(), remoteTransport.close()]);
+}
+
+localTransport.onmessage = (message) => {
+  const transformed = sessionState.fromClient(message);
+  const target = transformed.response ? localTransport : remoteTransport;
+  const outgoing = transformed.response ?? transformed.message;
+
+  void target.send(outgoing).catch((error) => {
+    reportError("message forwarding failed", error);
+    void closeTransports();
+  });
+};
+
+remoteTransport.onmessage = (message) => {
+  void localTransport.send(sessionState.fromServer(message)).catch((error) => {
+    reportError("response forwarding failed", error);
+    void closeTransports();
+  });
+};
+
+localTransport.onerror = (error) =>
+  reportError("Claude transport error", error);
+remoteTransport.onerror = (error) =>
+  reportError("remote transport error", error);
+localTransport.onclose = () => void closeTransports();
+remoteTransport.onclose = () => void closeTransports();
+
+process.once("SIGINT", () => void closeTransports());
+process.once("SIGTERM", () => void closeTransports());
+
+await remoteTransport.start();
+await localTransport.start();

--- a/server/session-state.js
+++ b/server/session-state.js
@@ -1,0 +1,271 @@
+const REQUIRED_STATE_MARKER = "REQUIRED WORKFLOW STATE:";
+
+const SESSION_DESCRIPTION =
+  "Required runtime identifier for an existing dataset. Copy session_id unchanged from the same tool result as table_name. Never omit, rename, modify, or invent it.";
+
+const TABLE_DESCRIPTION =
+  "Dataset table identifier. Copy table_name unchanged from the same tool result as session_id. Never combine values from different results.";
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasMessageId(message) {
+  return isObject(message) && message.id !== undefined && message.id !== null;
+}
+
+function isRequestMessage(message) {
+  return hasMessageId(message) && typeof message.method === "string";
+}
+
+function isResponseMessage(message) {
+  return (
+    hasMessageId(message) &&
+    message.method === undefined &&
+    (message.result !== undefined || message.error !== undefined)
+  );
+}
+
+function parseJsonText(text) {
+  if (typeof text !== "string") return null;
+
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function getSessionTablePair(value) {
+  if (
+    isObject(value) &&
+    typeof value.session_id === "string" &&
+    value.session_id.startsWith("session_") &&
+    typeof value.table_name === "string" &&
+    value.table_name.length > 0
+  ) {
+    return { sessionId: value.session_id, tableName: value.table_name };
+  }
+
+  return null;
+}
+
+function annotateStatefulTool(tool) {
+  if (!isObject(tool) || !isObject(tool.inputSchema)) return tool;
+
+  const required = Array.isArray(tool.inputSchema.required)
+    ? tool.inputSchema.required
+    : [];
+  if (!required.includes("session_id") || !required.includes("table_name"))
+    return tool;
+
+  const guidance = `${REQUIRED_STATE_MARKER}\nCopy both session_id and table_name unchanged from the same preceding tool result. Never invent either value. This tool does not create a session.`;
+  const description =
+    typeof tool.description === "string" ? tool.description : "";
+  const properties = isObject(tool.inputSchema.properties)
+    ? tool.inputSchema.properties
+    : {};
+  const sessionSchema = isObject(properties.session_id)
+    ? properties.session_id
+    : {};
+  const tableSchema = isObject(properties.table_name)
+    ? properties.table_name
+    : null;
+
+  return {
+    ...tool,
+    description: description.startsWith(REQUIRED_STATE_MARKER)
+      ? description
+      : `${guidance}${description ? `\n\n${description}` : ""}`,
+    inputSchema: {
+      ...tool.inputSchema,
+      properties: {
+        ...properties,
+        session_id: {
+          ...sessionSchema,
+          description: SESSION_DESCRIPTION,
+        },
+        ...(tableSchema
+          ? {
+              table_name: {
+                ...tableSchema,
+                description: TABLE_DESCRIPTION,
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+function missingSessionResponse(request, reason) {
+  const toolName = request.params.name;
+  let suffix =
+    "The extension has not observed an unambiguous session_id for this table.";
+  if (reason === "wrong-key") {
+    suffix = "The request used sessionId, but the required key is session_id.";
+  } else if (reason === "ambiguous") {
+    suffix =
+      "Multiple observed sessions contain this table name, so the extension cannot choose safely.";
+  }
+
+  return {
+    jsonrpc: "2.0",
+    id: request.id,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `${toolName} was not executed. Required argument session_id is missing. ${suffix} Copy both session_id and table_name unchanged from the same result that created or fetched the dataset, then retry. Use the exact key session_id, not sessionId. Do not invent a value. If the source result is unavailable, rerun the source tool.`,
+        },
+      ],
+    },
+  };
+}
+
+export class SessionStateBridge {
+  constructor() {
+    this.pendingRequests = new Map();
+    this.requiredSessionTools = new Set();
+    this.sessionsByTable = new Map();
+  }
+
+  fromClient(message) {
+    if (!isObject(message)) return { message };
+
+    if (isRequestMessage(message)) {
+      this.pendingRequests.set(message.id, message);
+    }
+
+    if (message.method !== "tools/call" || !isObject(message.params)) {
+      return { message };
+    }
+
+    const toolName = message.params.name;
+    if (
+      typeof toolName !== "string" ||
+      !this.requiredSessionTools.has(toolName)
+    ) {
+      return { message };
+    }
+
+    const originalArguments = isObject(message.params.arguments)
+      ? message.params.arguments
+      : {};
+    const args = { ...originalArguments };
+
+    if (args.session_id === undefined && args.sessionId !== undefined) {
+      if (hasMessageId(message)) {
+        this.pendingRequests.delete(message.id);
+        return { response: missingSessionResponse(message, "wrong-key") };
+      }
+      return { message };
+    }
+
+    if (args.session_id !== undefined) {
+      return {
+        message: {
+          ...message,
+          params: { ...message.params, arguments: args },
+        },
+      };
+    }
+
+    const tableName =
+      typeof args.table_name === "string" ? args.table_name : null;
+    const sessions = tableName
+      ? this.sessionsByTable.get(tableName)
+      : undefined;
+
+    if (sessions?.size === 1) {
+      args.session_id = sessions.values().next().value;
+      return {
+        message: {
+          ...message,
+          params: { ...message.params, arguments: args },
+        },
+      };
+    }
+
+    if (hasMessageId(message)) {
+      this.pendingRequests.delete(message.id);
+      return {
+        response: missingSessionResponse(
+          message,
+          sessions && sessions.size > 1 ? "ambiguous" : "unknown",
+        ),
+      };
+    }
+
+    return { message };
+  }
+
+  fromServer(message) {
+    if (!isResponseMessage(message)) return message;
+
+    const request = this.pendingRequests.get(message.id);
+    if (!request) return message;
+    this.pendingRequests.delete(message.id);
+
+    if (
+      request.method === "tools/list" &&
+      isObject(message.result) &&
+      Array.isArray(message.result.tools)
+    ) {
+      if (!request.params?.cursor) this.requiredSessionTools.clear();
+
+      const tools = message.result.tools.map((tool) => {
+        const annotated = annotateStatefulTool(tool);
+        if (annotated !== tool && typeof tool.name === "string") {
+          this.requiredSessionTools.add(tool.name);
+        }
+        return annotated;
+      });
+
+      return {
+        ...message,
+        result: { ...message.result, tools },
+      };
+    }
+
+    if (
+      request.method === "tools/call" &&
+      isObject(message.result) &&
+      message.result.isError !== true
+    ) {
+      this.rememberResult(message.result);
+    }
+
+    return message;
+  }
+
+  rememberResult(result) {
+    const candidates = [];
+
+    if (isObject(result.structuredContent)) {
+      candidates.push(result.structuredContent);
+    }
+
+    if (Array.isArray(result.content)) {
+      for (const content of result.content) {
+        if (isObject(content) && content.type === "text") {
+          const parsed = parseJsonText(content.text);
+          if (parsed !== null) candidates.push(parsed);
+        }
+      }
+    }
+
+    for (const candidate of candidates) {
+      const pair = getSessionTablePair(candidate);
+      if (!pair) continue;
+
+      const sessions = this.sessionsByTable.get(pair.tableName) ?? new Set();
+      sessions.add(pair.sessionId);
+      this.sessionsByTable.set(pair.tableName, sessions);
+    }
+  }
+}

--- a/server/session-state.test.js
+++ b/server/session-state.test.js
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SessionStateBridge } from "./session-state.js";
+
+function listStatefulTool(bridge, toolName = "enrich-prospects") {
+  bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+
+  return bridge.fromServer({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      tools: [
+        {
+          name: toolName,
+          description: "Enrich an existing dataset.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              session_id: { type: "string", description: "Session ID" },
+              table_name: { type: "string", description: "Table name" },
+            },
+            required: ["session_id", "table_name"],
+          },
+        },
+      ],
+    },
+  });
+}
+
+function rememberTextResult(bridge, id, sessionId, tableName) {
+  bridge.fromClient({
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "fetch-entities", arguments: {} },
+  });
+  bridge.fromServer({
+    jsonrpc: "2.0",
+    id,
+    result: {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            session_id: sessionId,
+            table_name: tableName,
+          }),
+        },
+      ],
+    },
+  });
+}
+
+test("advertises explicit state-transfer instructions for required-session tools", () => {
+  const bridge = new SessionStateBridge();
+
+  const response = listStatefulTool(bridge);
+  const [tool] = response.result.tools;
+
+  assert.match(tool.description, /^REQUIRED WORKFLOW STATE:/);
+  assert.match(tool.description, /same preceding tool result/);
+  assert.match(
+    tool.inputSchema.properties.session_id.description,
+    /Copy session_id unchanged/,
+  );
+  assert.match(
+    tool.inputSchema.properties.table_name.description,
+    /same tool result as session_id/,
+  );
+});
+
+test("injects an observed session_id when table_name has one unambiguous session", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+  rememberTextResult(bridge, 2, "session_alpha", "prospects_alpha");
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: { table_name: "prospects_alpha", enrichments: ["email"] },
+    },
+  });
+
+  assert.equal(
+    transformed.message.params.arguments.session_id,
+    "session_alpha",
+  );
+  assert.deepEqual(transformed.message.params.arguments.enrichments, ["email"]);
+});
+
+test("learns session state from structuredContent", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+  bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "fetch-entities", arguments: {} },
+  });
+  bridge.fromServer({
+    jsonrpc: "2.0",
+    id: 2,
+    result: {
+      structuredContent: {
+        session_id: "session_structured",
+        table_name: "prospects_structured",
+      },
+    },
+  });
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: { table_name: "prospects_structured" },
+    },
+  });
+
+  assert.equal(
+    transformed.message.params.arguments.session_id,
+    "session_structured",
+  );
+});
+
+test("rejects sessionId instead of silently renaming a client argument", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: { sessionId: "session_exact", table_name: "prospects_exact" },
+    },
+  });
+
+  assert.equal(transformed.message, undefined);
+  assert.equal(transformed.response.result.isError, true);
+  assert.match(transformed.response.result.content[0].text, /used sessionId/);
+  assert.match(
+    transformed.response.result.content[0].text,
+    /required key is session_id/,
+  );
+});
+
+test("preserves an explicit session_id instead of replacing it", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+  rememberTextResult(bridge, 2, "session_observed", "prospects_shared");
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: {
+        session_id: "session_explicit",
+        table_name: "prospects_shared",
+      },
+    },
+  });
+
+  assert.equal(
+    transformed.message.params.arguments.session_id,
+    "session_explicit",
+  );
+});
+
+test("refuses to guess when a table name maps to multiple sessions", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+  rememberTextResult(bridge, 2, "session_first", "prospects_shared");
+  rememberTextResult(bridge, 3, "session_second", "prospects_shared");
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: { table_name: "prospects_shared" },
+    },
+  });
+
+  assert.equal(transformed.message, undefined);
+  assert.equal(transformed.response.result.isError, true);
+  assert.match(
+    transformed.response.result.content[0].text,
+    /cannot choose safely/,
+  );
+});
+
+test("returns actionable recovery when no session mapping is available", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+
+  const transformed = bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "enrich-prospects",
+      arguments: { table_name: "prospects_unknown" },
+    },
+  });
+
+  assert.equal(transformed.response.result.isError, true);
+  assert.match(transformed.response.result.content[0].text, /was not executed/);
+  assert.match(
+    transformed.response.result.content[0].text,
+    /same result that created or fetched the dataset/,
+  );
+  assert.match(transformed.response.result.content[0].text, /not sessionId/);
+  assert.match(
+    transformed.response.result.content[0].text,
+    /rerun the source tool/,
+  );
+});
+
+test("does not learn session state from failed or nested result data", () => {
+  const bridge = new SessionStateBridge();
+  listStatefulTool(bridge);
+
+  bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "fetch-entities", arguments: {} },
+  });
+  bridge.fromServer({
+    jsonrpc: "2.0",
+    id: 2,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            session_id: "session_failed",
+            table_name: "prospects_failed",
+          }),
+        },
+      ],
+    },
+  });
+  bridge.rememberResult({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          preview: [
+            { session_id: "session_nested", table_name: "prospects_nested" },
+          ],
+        }),
+      },
+    ],
+  });
+
+  for (const tableName of ["prospects_failed", "prospects_nested"]) {
+    const transformed = bridge.fromClient({
+      jsonrpc: "2.0",
+      id: tableName,
+      method: "tools/call",
+      params: {
+        name: "enrich-prospects",
+        arguments: { table_name: tableName },
+      },
+    });
+    assert.equal(transformed.response.result.isError, true);
+  }
+});
+
+test("keeps client request correlation separate from reverse-direction messages", () => {
+  const bridge = new SessionStateBridge();
+  bridge.fromClient({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {},
+  });
+  const serverRequest = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "sampling/createMessage",
+    params: {},
+  };
+
+  assert.equal(bridge.fromServer(serverRequest), serverRequest);
+  const clientResponse = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { model: "sampled response" },
+  };
+  assert.equal(bridge.fromClient(clientResponse).message, clientResponse);
+
+  const response = bridge.fromServer({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      tools: [
+        {
+          name: "enrich-prospects",
+          inputSchema: {
+            type: "object",
+            properties: {
+              session_id: { type: "string" },
+              table_name: { type: "string" },
+            },
+            required: ["session_id", "table_name"],
+          },
+        },
+      ],
+    },
+  });
+
+  assert.match(
+    response.result.tools[0].description,
+    /^REQUIRED WORKFLOW STATE:/,
+  );
+});
+
+test("passes non-stateful tools and unrelated protocol messages through unchanged", () => {
+  const bridge = new SessionStateBridge();
+  const call = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "autocomplete",
+      arguments: { query: "software companies" },
+    },
+  };
+  const notification = {
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  };
+
+  assert.equal(bridge.fromClient(call).message, call);
+  assert.equal(bridge.fromClient(notification).message, notification);
+  assert.equal(bridge.fromServer(notification), notification);
+});


### PR DESCRIPTION
## Summary
- prevent Claude Desktop workflows from losing required `session_id` state between MCP tool calls
- keep OAuth and remote transport behavior delegated to the existing `mcp-remote` proxy

## Changes
- route the extension through a transparent local stdio bridge
- strengthen `tools/list` guidance for tools requiring the `session_id`/`table_name` pair
- remember only successful top-level state pairs observed in the current process
- inject `session_id` only when the exact `table_name` maps to one observed session
- return actionable `isError` results for missing, misspelled, unknown, or ambiguous session state
- preserve all unrelated MCP requests, responses, and notifications

## Testing
- [x] `npm test` — 10/10 passing
- [x] Node syntax checks
- [x] `git diff --check`
- [x] `mcpb pack` — manifest validation passed
- [x] Live MCP Inspector `tools/list` — 14 tools discovered; 7 stateful tools annotated
- [x] Live missing-session call — intercepted locally with actionable `isError` result before remote execution
- [x] Autoreview — clean