### PR TITLE
Fix Vibe Prospecting OAuth on current Claude Desktop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify MCP proxy build
+        run: npm run verify
 
       - name: Install MCPB tool
         run: npm install -g @anthropic-ai/mcpb

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "Vibe Prospecting",
   "display_name": "Vibe Prospecting",
-  "version": "2.0.1",
+  "version": "2.0.9",
   "description": "Power your chat with B2B data to create lead lists, research companies, personalize your outreach, and more.",
   "long_description": "Search any company or professional to access emails, phone numbers, roles, growth signals, tech stack details, business events, website changes, and more. Use it to **find qualified leads**, **research prospects**, **create personalized outreach**, or **identify talent**, all directly within your chat. Vibe Prospecting provides fresh and compliant B2B data through a complete enrichment hub.",
   "author": {
@@ -21,7 +21,7 @@
   "tools_generated": true,
   "server": {
     "type": "node",
-    "entry_point": "server/index.js",
+    "entry_point": "node_modules/mcp-remote/dist/proxy.js",
     "mcp_config": {
       "command": "node",
       "args": [
@@ -42,9 +42,13 @@
   "license": "MIT",
   "compatibility": {
     "claude_desktop": ">=0.10.0",
-    "platforms": ["darwin", "win32", "linux"],
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
     "runtimes": {
-      "node": ">=18.0.0"
+      "node": ">=20.18.1"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "explorium-mcp-extension",
-  "version": "2.0.1",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explorium-mcp-extension",
-      "version": "2.0.1",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "express": "^5.2.1",
-        "mcp-remote": "^0.1.38"
+        "mcp-remote": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7"
+      },
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@hono/node-server": {
@@ -798,9 +801,9 @@
       }
     },
     "node_modules/mcp-remote": {
-      "version": "0.1.38",
-      "resolved": "https://registry.npmjs.org/mcp-remote/-/mcp-remote-0.1.38.tgz",
-      "integrity": "sha512-w+JU4U3CfG29TawXR4JLNQ9d1Un5nT8AGI65f/juCaqUdF/V6fS7wE4o7xNPbB8X58o46hRXEJgYglQMAKQs4w==",
+      "version": "0.2.1",
+      "resolved": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7",
+      "integrity": "sha512-Kma0g+msF2gXMi++q041YkVrhIO5Y4S/lHV41MkINqafTnDMtS0oARmSFZq4mWS0YwQybjzrkRGn14TNTgtNyg==",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "express": "^5.2.1",
-        "mcp-remote": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7"
+        "mcp-remote": "https://github.com/explorium-ai/mcp-remote/releases/download/v0.2.1-explorium.1/mcp-remote-0.2.1.tgz"
       },
       "engines": {
         "node": ">=20.18.1"
@@ -802,8 +802,8 @@
     },
     "node_modules/mcp-remote": {
       "version": "0.2.1",
-      "resolved": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7",
-      "integrity": "sha512-Kma0g+msF2gXMi++q041YkVrhIO5Y4S/lHV41MkINqafTnDMtS0oARmSFZq4mWS0YwQybjzrkRGn14TNTgtNyg==",
+      "resolved": "https://github.com/explorium-ai/mcp-remote/releases/download/v0.2.1-explorium.1/mcp-remote-0.2.1.tgz",
+      "integrity": "sha512-HF7o8v3smLAxIcgx/jzEFOGmaN1Mg5flw6AVY1Ro0ucVRCwub0un8zl338bxiOF8/N9V/dOK9/cMT8D1CZZDtw==",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "express": "^5.2.1",
-    "mcp-remote": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7"
+    "mcp-remote": "https://github.com/explorium-ai/mcp-remote/releases/download/v0.2.1-explorium.1/mcp-remote-0.2.1.tgz"
   },
   "author": "explorium.ai",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,20 @@
 {
   "name": "explorium-mcp-extension",
-  "version": "2.0.1",
+  "version": "2.0.9",
   "description": "Explorium MCP Extension for Claude Desktop using mcp-remote",
   "main": "server/index.js",
   "scripts": {
-    "start": "node server/index.js"
+    "start": "node server/index.js",
+    "verify": "node -e \"require('node:fs').accessSync('node_modules/mcp-remote/dist/proxy.js')\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "express": "^5.2.1",
-    "mcp-remote": "^0.1.38"
+    "mcp-remote": "git+https://github.com/explorium-ai/mcp-remote.git#56e61d23c305c8872a7d38c512d255bf7a2dbec7"
   },
   "author": "explorium.ai",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.18.1"
+  }
 }


### PR DESCRIPTION
## Summary

- consume the immutable `mcp-remote v0.2.1-explorium.1` release asset
- launch patched `mcp-remote` directly instead of the custom nested-process bridge
- bump the extension to `2.0.9`
- build releases with Node 22 and declare the actual Node runtime floor
- fail extension packaging if the bundled dependency lacks `dist/proxy.js`

## Why

Current Claude Desktop starts and replaces several stdio extension processes during OAuth. `mcp-remote@0.1.38` races over callback, PKCE, and client-registration state. The custom bridge then fails on current Claude because its nested child uses `Claude Helper (Plugin)` as `process.execPath` and exits with `SIGTRAP`.

This bundles `mcp-remote v0.2.1` plus the lifecycle fix from upstream PR geelen/mcp-remote#320.

## Dependency

- merged fork PR: explorium-ai/mcp-remote#1
- release: https://github.com/explorium-ai/mcp-remote/releases/tag/v0.2.1-explorium.1
- source commit: `6eeeeceab1d567787aa1af22d42a927f519d5034`
- release tarball SHA-256: `30dea8b57d8d149561c986139306e1217f78f3aebc9eec49ee9186c36450dec9`

## Validation

- clean `npm ci` under Node 22 with an isolated npm cache
- MCP proxy build verification
- MCPB manifest validation
- MCPB packaging
- clean-cache macOS Claude Desktop OAuth test
- exactly one OAuth tab
- authentication and extension tool loading succeeded

## Before merge

- validate clean-cache OAuth on Windows 11
- review the released proxy dependency and lockfile integrity

No release has been created from this branch.
